### PR TITLE
Force delays starting failover. Debug flag during install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - IRIS_hostname=serverA
       - IRIS_mirrorname=MIRRORSET
       - IRIS_arbitername=arbiter
+      - IRIS_debugInstall=1
     ports:
       - "9092:52773"
     command:
@@ -38,6 +39,7 @@ services:
       - IRIS_hostname=serverB
       - IRIS_mirrorname=MIRRORSET
       - IRIS_arbitername=arbiter
+      - IRIS_debugInstall=1
     ports:
       - "9093:52773"
 

--- a/install/Installer.cls
+++ b/install/Installer.cls
@@ -3,7 +3,7 @@ Include %occInclude
 Class Mirror.Installer
 {
 
-ClassMethod setup(hostname,pMirrorName as %String = "MIRRORSET",pArbiterName as %String="arbiter") As %Status
+ClassMethod setup(hostname,pMirrorName as %String = "MIRRORSET",pArbiterName as %String="arbiter",pDebug as %Boolean=0) As %Status
 {
   // For demos - avoid the need to set a new password in first login
   do ##class(Security.Users).UnExpireUserPasswords("*")
@@ -23,15 +23,16 @@ ClassMethod setup(hostname,pMirrorName as %String = "MIRRORSET",pArbiterName as 
     } 
     else 
     {
-      //h 5 ///Give additional time for serverA start up
+      h 5 ///Give additional time for serverA start up
       do ..joinAsFailover("serverB","serverA",pMirrorName)
     }
 
     // Allow some time to create mirror before creating DDBB
-    for i=1:1:10 
+    for i=1:1:20 
     {
       h 1
       set mirrorSt=$LIST($SYSTEM.Mirror.GetMemberStatus(pMirrorName))
+      set:pDebug ^dbgFlag(hostname,"loop",$I(^dbgFlag))=mirrorSt
       quit:$case(mirrorSt,"Backup":1,"Primary":1,"Connected":1,:0)
     }
 
@@ -47,23 +48,25 @@ ClassMethod setup(hostname,pMirrorName as %String = "MIRRORSET",pArbiterName as 
   quit $$$OK
 }
 
-ClassMethod createMirror(hostname, pMirrorName as %String="MIRRORSET", pArbiterName as %String="arbiter") As %Status
+ClassMethod createMirror(hostname, pMirrorName as %String="MIRRORSET", pArbiterName as %String="arbiter",pDebug as %Boolean=0) As %Status
 {
   // Create mirror:
   set mirror("UseSSL") = 0
   set mirror("ArbiterNode") = pArbiterName_"|2188"
   set sc = ##class(SYS.Mirror).CreateNewMirrorSet(pMirrorName, hostname, .mirror)
+  set:pDebug ^dbgFlag(hostname,"createMirror")=sc
   write !,"Creating mirror "_pMirrorName_"..."
 
   if 'sc do $system.OBJ.DisplayError(sc)  
   quit sc
 }
 
-ClassMethod joinAsFailover(hostnameFrom, hostnameTo, pMirrorName as %String="MIRRORSET") As %Status
+ClassMethod joinAsFailover(hostnameFrom, hostnameTo, pMirrorName as %String="MIRRORSET",pDebug as %Boolean=0) As %Status
 {
   set instanceName="IRIS"
   // Join as failover:
   s sc=##class(SYS.Mirror).JoinMirrorAsFailoverMember(pMirrorName,hostnameFrom,instanceName,hostnameTo,,.MirrorInfo)
+  set:pDebug ^dbgFlag(hostnameFrom,"joinAsFailover")=sc
   write !,"Jonining mirror "_pMirrorName_"..."
   if 'sc do $system.OBJ.DisplayError(sc)
   quit sc
@@ -77,10 +80,10 @@ ClassMethod enableMirrorService() As %Status
   write !,"Enabling mirror service..."
 }
 
-ClassMethod createMirrorDB(pMirrorName as %String="MIRRORSET") As %Status
+ClassMethod createMirrorDB(pMirrorName as %String="MIRRORSET",pDebug as %Boolean=0) As %Status
 {
-  //set dir="/ISC/"
   set dir = $system.Util.InstallDirectory()_"/mgr/"
+  set:pDebug ^dbgFlag("createMirrorDB","dir")=dir
   set dirName="mirrorDB"
   set mirDBName="MIRRORDB"
   set mirNSName="MIRRORNS"
@@ -94,22 +97,25 @@ ClassMethod createMirrorDB(pMirrorName as %String="MIRRORSET") As %Status
   set Properties("Directory")=dir_dirName
   do ##class(Config.Databases).Create(mirDBName,.Properties)
  
-  set rc = ##class(SYS.Database).CreateDatabase(dir_dirName,,,,,,mirDBName,pMirrorName)
-  if 'rc { 
+  set sc = ##class(SYS.Database).CreateDatabase(dir_dirName,,,,,,mirDBName,pMirrorName)
+  set:pDebug ^dbgFlag("createMirrorDB","status CreateDatabase")=sc
+ 
+  if 'sc { 
     write !,"Database creation failed!"
-    do $system.OBJ.DisplayError(rc)
-    quit rc
+    do $system.OBJ.DisplayError(sc)
+    quit sc
   }
   
   // Create namespace for mirrored database
   set ns("Globals")=mirDBName
   set ns("Routines")=mirDBName
-  do ##class(Config.Namespaces).Create(mirNSName,.ns)
-  set rc = ##class(Config.Namespaces).Exists(mirNSName,.obj,.status)
-  if 'rc {
+  set sc =##class(Config.Namespaces).Create(mirNSName,.ns)
+  set:pDebug ^dbgFlag("createMirrorNS","status CreateMirrorNS")=sc
+
+  if 'sc {
     write !, "NS creation failed."
-    do $system.OBJ.DisplayError(rc)
-    quit rc
+    do $system.OBJ.DisplayError(sc)
+    quit sc
   }
     
   quit $$$OK

--- a/install/installer.sh
+++ b/install/installer.sh
@@ -2,7 +2,7 @@ nohup $IRISSYS/ISCAgentUser start &>/dev/null &
 sleep 1
 iris session $ISC_PACKAGE_INSTANCENAME -U %SYS << END
 do \$SYSTEM.OBJ.Load("/install/Installer.cls", "ck") \
-set sc = ##class(Mirror.Installer).setup("$IRIS_hostname","$IRIS_mirrorname","$IRIS_arbitername") \
+set sc = ##class(Mirror.Installer).setup("$IRIS_hostname","$IRIS_mirrorname","$IRIS_arbitername","$IRIS_debugInstall") \
 halt
 END
 


### PR DESCRIPTION
In case of a slow system, the mirror can fail to start properly configured. I added 5 s delay for the backup and also code to allow trace during start process. Install.cls will set trace of activity in ^dbgFlag global in %SYS in both, Primary and Backup.